### PR TITLE
replace unmaintained actions-rs/* actions in CI workflows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,35 +16,21 @@ jobs:
       name: Rustfmt
       runs-on: ubuntu-latest
       steps:
-        - uses: actions-rs/toolchain@v1
-          with:
-            profile: minimal
-            toolchain: stable
-            override: true
+        - uses: dtolnay/rust-toolchain@stable
         - uses: Swatinem/rust-cache@v2
         - run: rustup component add rustfmt
         - uses: actions/checkout@v3
-        - uses: actions-rs/cargo@v1
-          with:
-            command: fmt
-            args: --all -- --check
+        - run: cargo fmt --all -- --check
   # Clippy
   clippy:
     if: github.event.pull_request.draft == false
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt-get update
       - run: sudo apt install libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev
       - run: rustup component add clippy
       - uses: actions/checkout@v3
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --examples --tests -- -D warnings
+      - run: cargo clippy --workspace --examples --tests -- -D warnings


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, for example in https://github.com/DioxusLabs/dioxus-std/actions/runs/5282023756:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1, actions-rs/cargo@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

To get rid of those warnings the occurrences of `actions-rs/toolchain` are replaced by [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain), and the occurrences of `actions-rs/cargo` are replaced by direct invocations of `cargo`.